### PR TITLE
feat: Implement backgammon move validation logic

### DIFF
--- a/src/GameLogic/validation.test.ts
+++ b/src/GameLogic/validation.test.ts
@@ -1,0 +1,231 @@
+import { isValidMove } from './validation';
+import { type GameType } from '../Types';
+import { DEFAULT_BOARD, newGame } from '../Utils'; // Assuming newGame and DEFAULT_BOARD are exported from Utils
+
+// Helper function to create game states
+const createGameState = (
+  boardSetup: number[] | null,
+  dice: [number, number],
+  color: 'white' | 'black',
+  whitePrison: number = 0,
+  blackPrison: number = 0,
+  whiteHome: number = 0,
+  blackHome: number = 0
+): GameType => {
+  const game = newGame();
+  if (boardSetup) {
+    game.board = [...boardSetup];
+  } else {
+    game.board = [...DEFAULT_BOARD];
+  }
+  game.dice = dice;
+  game.color = color;
+  game.turn = 'player1'; // Dummy turn ID
+  game.prison = { white: whitePrison, black: blackPrison };
+  game.home = { white: whiteHome, black: blackHome };
+  game.status = 'rolled'; // Assume dice have been rolled
+  return game;
+};
+
+describe('isValidMove - Standard Moves', () => {
+  it('should allow White to move to an empty point with correct die', () => {
+    const board = [...DEFAULT_BOARD];
+    board[11] = 1; // White piece on point 12 (0-indexed: 11)
+    board[5] = 0;  // Point 6 (0-indexed: 5) is empty
+    const game = createGameState(board, [6, 1], 'white');
+    expect(isValidMove(game, 11, 5, 6)).toBe(true);
+  });
+
+  it('should allow Black to move to their own piece with correct die', () => {
+    const board = [...DEFAULT_BOARD];
+    board[12] = -1; // Black piece on point 13 (0-indexed: 12)
+    board[17] = -1; // Black piece on point 18 (0-indexed: 17)
+    const game = createGameState(board, [5, 2], 'black');
+    expect(isValidMove(game, 12, 17, 5)).toBe(true);
+  });
+
+  it('should allow White to hit a Black blot', () => {
+    const board = [...DEFAULT_BOARD];
+    board[20] = 1;  // White piece on point 21 (0-indexed: 20)
+    board[17] = -1; // Black blot on point 18 (0-indexed: 17)
+    const game = createGameState(board, [3, 4], 'white');
+    expect(isValidMove(game, 20, 17, 3)).toBe(true);
+  });
+
+  it('should not allow Black to land on White\'s blocked point', () => {
+    const board = [...DEFAULT_BOARD];
+    board[5] = -1; // Black piece on point 6 (0-indexed: 5)
+    board[8] = 2;  // White blocked point at 9 (0-indexed: 8)
+    const game = createGameState(board, [3, 1], 'black');
+    expect(isValidMove(game, 5, 8, 3)).toBe(false);
+  });
+
+  it('should not allow White to move in the wrong direction', () => {
+    const board = [...DEFAULT_BOARD];
+    board[5] = 1; // White piece on point 6 (0-indexed: 5)
+    const game = createGameState(board, [3, 1], 'white');
+    expect(isValidMove(game, 5, 8, 3)).toBe(false); // Attempting to move 5 to 8 (black's direction)
+  });
+
+  it('should not allow Black to move if distance does not match die', () => {
+    const board = [...DEFAULT_BOARD];
+    board[12] = -1;
+    const game = createGameState(board, [5, 2], 'black');
+    expect(isValidMove(game, 12, 18, 5)).toBe(false); // Should be 12 to 17 for die 5
+  });
+
+  it('should not allow moving opponent\'s piece', () => {
+    const board = [...DEFAULT_BOARD];
+    board[11] = -1; // Black piece on point 12
+    const game = createGameState(board, [6, 1], 'white'); // White's turn
+    expect(isValidMove(game, 11, 5, 6)).toBe(false);
+  });
+
+  it('should not allow moving from an empty point', () => {
+    const board = [...DEFAULT_BOARD];
+    board[11] = 0; // Point 12 is empty
+    const game = createGameState(board, [6, 1], 'white');
+    expect(isValidMove(game, 11, 5, 6)).toBe(false);
+  });
+});
+
+describe('isValidMove - Re-entry from Bar', () => {
+  it('should allow White to re-enter from bar to an empty point with die 3', () => {
+    // Point 3 (0-indexed: 2)
+    const game = createGameState([...DEFAULT_BOARD], [3, 1], 'white', 1);
+    game.board[2] = 0; // Ensure point 3 is empty
+    expect(isValidMove(game, 'white', 2, 3)).toBe(true);
+  });
+
+  it('should allow Black to re-enter from bar and hit a White blot with die 5', () => {
+    // Target point 20 (0-indexed: 19, since 24 - 5 = 19)
+    const board = [...DEFAULT_BOARD];
+    board[19] = 1; // White blot on point 20
+    const game = createGameState(board, [5, 2], 'black', 0, 1);
+    expect(isValidMove(game, 'black', 19, 5)).toBe(true);
+  });
+
+  it('should not allow White to re-enter if target point is blocked by Black', () => {
+    const board = [...DEFAULT_BOARD];
+    board[3] = -2; // Black blocks point 4 (0-indexed: 3)
+    const game = createGameState(board, [4, 1], 'white', 1);
+    expect(isValidMove(game, 'white', 3, 4)).toBe(false);
+  });
+
+  it('should not allow Black to re-enter if "from" is a board point', () => {
+    const game = createGameState([...DEFAULT_BOARD], [5, 2], 'black', 0, 1);
+    expect(isValidMove(game, 0, 19, 5)).toBe(false); // from is 0, not 'black'
+  });
+  
+  it('should not allow White to re-enter if "to" point does not match die', () => {
+    const game = createGameState([...DEFAULT_BOARD], [3, 1], 'white', 1);
+    expect(isValidMove(game, 'white', 1, 3)).toBe(false); // Die 3, target should be 2, not 1
+  });
+
+  it('should not allow re-entry attempt if no pieces are on the bar', () => {
+    const game = createGameState([...DEFAULT_BOARD], [3, 1], 'white', 0); // No pieces on bar
+    expect(isValidMove(game, 'white', 2, 3)).toBe(false);
+  });
+
+   it('should not allow a board move if player has pieces on the bar', () => {
+    const game = createGameState([...DEFAULT_BOARD], [3,1], 'white', 1); // White has piece on bar
+    game.board[11] = 1; // White piece on board
+    expect(isValidMove(game, 11, 8, 3)).toBe(false); // Attempting board move
+  });
+});
+
+describe('isValidMove - Bearing Off', () => {
+  const allWhiteHomeBoard = () => {
+    const board = Array(24).fill(0);
+    board[0] = 2; board[1] = 2; board[2] = 2; board[3] = 2; board[4] = 2; board[5] = 5; // 15 pieces
+    return board;
+  };
+  const allBlackHomeBoard = () => {
+    const board = Array(24).fill(0);
+    board[18] = -2; board[19] = -2; board[20] = -2; board[21] = -2; board[22] = -2; board[23] = -5; // 15 pieces
+    return board;
+  };
+
+  it('should allow White to bear off with exact die when all pieces are home', () => {
+    const game = createGameState(allWhiteHomeBoard(), [3, 1], 'white');
+    // Bearing off from point 3 (0-indexed: 2) with die 3
+    expect(isValidMove(game, 2, 'off', 3)).toBe(true);
+  });
+
+  it('should allow Black to bear off with exact die when all pieces are home', () => {
+    const game = createGameState(allBlackHomeBoard(), [4, 2], 'black');
+    // Bearing off from point 21 (0-indexed: 20) with die 4 (24-4 = 20)
+    expect(isValidMove(game, 20, 'off', 4)).toBe(true);
+  });
+
+  it('should allow White to bear off with higher die when all pieces are home and it\'s the furthest piece', () => {
+    const board = allWhiteHomeBoard();
+    board[5] = 1; // Furthest piece is on point 6 (0-indexed: 5)
+    board[4] = 0; board[3] = 0; // Clear higher points for this test
+    const game = createGameState(board, [6, 1], 'white');
+    // Try to bear off piece from point 6 (idx 5) with die 6 (exact) - This is the setup
+    // Now, if piece was at idx 2 (point 3), die 5 should take it off if 5,4 are empty
+    board[5]=0; board[4]=0; board[3]=0; board[2]=1; // piece at point 3 (idx 2)
+    const game2 = createGameState(board, [5,1], 'white');
+    expect(isValidMove(game2, 2, 'off', 5)).toBe(true);
+  });
+
+  it('should allow Black to bear off with higher die when all pieces are home and it\'s the furthest piece', () => {
+    const board = allBlackHomeBoard();
+    board[18] = -1; // Furthest piece is on point 19 (0-indexed: 18)
+    board[19] = 0; board[20] = 0; // Clear higher points
+    const game = createGameState(board, [6, 1], 'black');
+     // Try to bear off piece from point 19 (idx 18) with die 6 (exact)
+    // Now, if piece was at idx 21 (point 22), die 5 (target 24-5=19) should take it off if 19,20 are empty
+    board[18]=0; board[19]=0; board[20]=0; board[21]=-1; // piece at point 22 (idx 21)
+    const game2 = createGameState(board, [5,1], 'black');
+    expect(isValidMove(game2, 21, 'off', 5)).toBe(true);
+  });
+  
+  it('should NOT allow White to bear off with higher die if there is a piece on a higher point', () => {
+    const board = allWhiteHomeBoard();
+    board[2] = 1; // Piece on point 3 (idx 2)
+    board[4] = 1; // Piece on point 5 (idx 4) - this should be moved first
+    const game = createGameState(board, [5,1], 'white'); // Die 5
+    expect(isValidMove(game, 2, 'off', 5)).toBe(false); // Cannot bear off from point 3 if point 5 has a piece
+  });
+
+
+  it('should not allow White to bear off if pieces are outside home board', () => {
+    const board = allWhiteHomeBoard();
+    board[6] = 1; // Piece on point 7 (outside home)
+    const game = createGameState(board, [3, 1], 'white');
+    expect(isValidMove(game, 2, 'off', 3)).toBe(false);
+  });
+
+  it('should not allow Black to bear off if piece is on the bar', () => {
+    const game = createGameState(allBlackHomeBoard(), [4, 2], 'black', 0, 1); // Black piece on bar
+    expect(isValidMove(game, 20, 'off', 4)).toBe(false);
+  });
+
+  it('should not allow White to bear off if die does not match point and not covered by higher die rule', () => {
+    const game = createGameState(allWhiteHomeBoard(), [3, 1], 'white');
+    // Attempt to bear off from point 5 (0-indexed: 4) with die 3. Point 3 (idx 2) is not empty.
+    expect(isValidMove(game, 4, 'off', 3)).toBe(false);
+  });
+  
+  it('should not allow White to bear off from a point not in the home board (e.g. point 7)', () => {
+    const game = createGameState(allWhiteHomeBoard(), [1,1], 'white');
+    // Technically, all pieces are home, but 'from' is invalid.
+    // isValidMove should catch from < 0 || from > 5 for white bearoff.
+    // This specific test is slightly redundant with the "pieces outside home" one if that one is general,
+    // but good for explicitness on `from` point.
+    // Let's ensure a piece is actually at point 7 for this test to be meaningful beyond just "all home"
+    const board = allWhiteHomeBoard(); // All home
+    board[6] = 1; // Add a white piece at point 7 (idx 6)
+    // Now, the "all pieces home" check in isValidMove should fail.
+    // If we manually bypass that and just test the from point:
+    // The `isValidMove` check `if (from < 0 || from > 5) return false;` for white bearoff should catch this.
+    // This test might be better framed as "cannot select 'from' outside home board for bearing off"
+    // But isValidMove's internal logic for bearoff (is all home? then is 'from' valid?) covers this.
+    // The existing "pieces outside home" test is more robust.
+    // For this test, let's make sure "all pieces are home" but from is wrong.
+    const gameAllHome = createGameState(allWhiteHomeBoard(), [1,1], 'white');
+    expect(isValidMove(gameAllHome, 6, 'off', 1)).toBe(false); // from=6 is point 7
+  });
+});

--- a/src/GameLogic/validation.ts
+++ b/src/GameLogic/validation.ts
@@ -1,0 +1,169 @@
+import { GameType } from '../Types';
+
+export const isValidMove = (
+  game: GameType,
+  from: number | 'white' | 'black',
+  to: number | 'off',
+  diceValue: number
+): boolean => {
+  const board = game.board;
+  let playerColor: 'white' | 'black' | null = game.color;
+  let opponentColorSign: number;
+  let playerColorSign: number;
+
+  if (playerColor === 'white') {
+    playerColorSign = 1;
+    opponentColorSign = -1;
+  } else if (playerColor === 'black') {
+    playerColorSign = -1;
+    opponentColorSign = 1;
+  } else {
+    return false; // Invalid game state
+  }
+
+  // 1. Re-entering logic (handles cases where player has pieces in prison)
+  if (playerColor === 'white' && game.prison.white > 0) {
+    if (from !== 'white' || typeof to !== 'number') return false;
+    const entryPointWhite = diceValue - 1;
+    if (to !== entryPointWhite) return false;
+    if (to < 0 || to > 5) return false; // Should be redundant if diceValue is 1-6
+    const toPointPieces = board[to];
+    if (Math.sign(toPointPieces) === opponentColorSign && Math.abs(toPointPieces) > 1) return false;
+    return true;
+  }
+
+  if (playerColor === 'black' && game.prison.black > 0) {
+    if (from !== 'black' || typeof to !== 'number') return false;
+    const entryPointBlack = 24 - diceValue;
+    if (to !== entryPointBlack) return false;
+    if (to < 18 || to > 23) return false; // Should be redundant if diceValue is 1-6
+    const toPointPieces = board[to];
+    if (Math.sign(toPointPieces) === opponentColorSign && Math.abs(toPointPieces) > 1) return false;
+    return true;
+  }
+
+  // If execution reaches here, player has no pieces on the bar.
+  // Now, handle bearing off OR standard board moves.
+
+  if (to === 'off') {
+    // --- BEARING OFF LOGIC ---
+    if (typeof from !== 'number') {
+      return false; // Cannot bear off from the bar (e.g. if from === 'white' but prison.white is 0)
+    }
+
+    // Check if all player's pieces are in their home board
+    let allPiecesInHomeBoard = true;
+    if (playerColor === 'white') {
+      if (game.prison.white > 0) { // Double check, though covered above
+        allPiecesInHomeBoard = false;
+      } else {
+        for (let i = 6; i <= 23; i++) { // Points 7 to 24
+          if (board[i] !== 0 && Math.sign(board[i]) === playerColorSign) {
+            allPiecesInHomeBoard = false;
+            break;
+          }
+        }
+      }
+    } else { // playerColor === 'black'
+      if (game.prison.black > 0) { // Double check
+        allPiecesInHomeBoard = false;
+      } else {
+        for (let i = 0; i <= 17; i++) { // Points 1 to 18
+          if (board[i] !== 0 && Math.sign(board[i]) === playerColorSign) {
+            allPiecesInHomeBoard = false;
+            break;
+          }
+        }
+      }
+    }
+
+    if (!allPiecesInHomeBoard) {
+      return false;
+    }
+
+    // Validate Bearing Off from the `from` Point
+    if (Math.sign(board[from]) !== playerColorSign) {
+        return false; // Not player's piece at 'from'
+    }
+
+    if (playerColor === 'white') {
+      if (from < 0 || from > 5) return false; // `from` must be in White's home board (0-5)
+
+      const targetPointForExactBearOff = diceValue - 1; // 0-indexed
+      if (from === targetPointForExactBearOff) {
+        return true; // Direct bear off
+      }
+      if (targetPointForExactBearOff > from) { // Rolled higher than the point
+        // Check if all points between targetPointForExactBearOff and 'from' are clear
+        for (let p = targetPointForExactBearOff; p > from; p--) {
+           // Check points from (diceValue-1) down to (from + 1)
+           // The problem states "iterate from p = diceValue - 1 down to from + 1"
+           // My loop is p > from, so it covers from+1 up to diceValue-1.
+           // Example: from=0 (point 1), dice=3 (target=2). Loop p=2 down to 1. board[p] (board[2], board[1])
+           // This seems to check points *higher* than 'from' correctly.
+           if (p >=0 && p <=5 && board[p] !== 0 && Math.sign(board[p]) === playerColorSign) {
+             return false; // Must move piece from a higher point first
+           }
+        }
+        return true; // Can bear off with higher die roll
+      }
+      return false; // Invalid bear-off (e.g. diceValue - 1 < from)
+    } else { // playerColor === 'black'
+      if (from < 18 || from > 23) return false; // `from` must be in Black's home board (18-23)
+      
+      const targetPointForExactBearOff = 24 - diceValue; // 0-indexed
+      if (from === targetPointForExactBearOff) {
+        return true; // Direct bear off
+      }
+      if (targetPointForExactBearOff < from) { // Rolled higher than the point (target is lower index for black)
+        // Check if all points between targetPointForExactBearOff and 'from' are clear
+        for (let p = targetPointForExactBearOff; p < from; p++) {
+            // Check points from (24-diceValue) up to (from -1)
+            // Example: from=23 (point 24), dice=3 (target=21). Loop p=21 up to 22. board[p] (board[21], board[22])
+            if (p >= 18 && p <= 23 && board[p] !== 0 && Math.sign(board[p]) === playerColorSign) {
+              return false; // Must move piece from a higher point first (closer to 24 for black)
+            }
+        }
+        return true; // Can bear off with higher die roll
+      }
+      return false; // Invalid bear-off (e.g. 24 - diceValue > from)
+    }
+
+  } else {
+    // --- STANDARD POINT-TO-POINT MOVE LOGIC ---
+    // Ensure 'from' and 'to' are numbers for standard moves.
+    if (typeof from !== 'number' || typeof to !== 'number') {
+      // If from is 'white'/'black', it implies moving from an empty bar (already handled if prison > 0).
+      // If to is 'off', it's handled above.
+      return false;
+    }
+
+    // Preliminary check for 'from' and 'to' point validity (0-23 range)
+    if (from < 0 || from > 23 || to < 0 || to > 23) {
+      return false;
+    }
+
+    // Check Piece at `from` Point
+    const fromPointPieces = board[from];
+    if (Math.sign(fromPointPieces) !== playerColorSign) {
+      return false;
+    }
+
+    // Direction of Movement & Target Point Calculation
+    if (playerColorSign === 1) { // White
+      if (to !== from - diceValue) return false;
+      if (to >= from) return false;
+    } else { // Black (playerColorSign === -1)
+      if (to !== from + diceValue) return false;
+      if (to <= from) return false;
+    }
+    
+    // Check Destination Point (`to`)
+    const toPointPiecesOnBoard = board[to];
+    if (Math.sign(toPointPiecesOnBoard) === opponentColorSign && Math.abs(toPointPiecesOnBoard) > 1) {
+      return false;
+    }
+
+    return true;
+  }
+};

--- a/src/Utils.test.ts
+++ b/src/Utils.test.ts
@@ -1,0 +1,191 @@
+import { calculateNewMove, newGame, DEFAULT_BOARD } from './Utils';
+import { type GameType } from './Types';
+// No need to import isValidMove directly for these tests, as we test calculateNewMove's behavior
+
+// Helper function to create game states
+const createGameState = (
+  options: {
+    board?: number[];
+    dice: [number, number] | [number, number, number, number]; // Allow for doubles
+    color: 'white' | 'black';
+    whitePrison?: number;
+    blackPrison?: number;
+    whiteHome?: number;
+    blackHome?: number;
+  }
+): GameType => {
+  const game = newGame(); // Start with a base new game
+  game.board = options.board ? [...options.board] : [...DEFAULT_BOARD];
+  game.dice = [...options.dice];
+  game.color = options.color;
+  game.turn = 'player1'; // Dummy turn ID, not used by calculateNewMove directly
+  game.prison = { white: options.whitePrison || 0, black: options.blackPrison || 0 };
+  game.home = { white: options.whiteHome || 0, black: options.blackHome || 0 };
+  game.status = 'rolled'; // Assume dice have been rolled
+  return game;
+};
+
+describe('calculateNewMove', () => {
+  describe('Valid Moves & State Changes', () => {
+    it('White standard move: piece from point 12 to 6 with die 6', () => {
+      const initialBoard = [...DEFAULT_BOARD];
+      initialBoard[11] = 1; // White piece on point 12 (0-indexed)
+      const game = createGameState({
+        board: initialBoard,
+        dice: [6, 2],
+        color: 'white',
+      });
+
+      const result = calculateNewMove(game, 11, 5, 6); // from point 12 to 6 (0-indexed)
+
+      expect(result.moveLabel).toBe('12/6');
+      expect(result.state.board[11]).toBe(0);
+      expect(result.state.board[5]).toBe(1);
+      expect(result.state.dice).toEqual(expect.arrayContaining([0, 2])); // 6 used, 2 remains
+      expect(result.state.status).toBe('moved');
+    });
+
+    it('Black standard move hitting a White blot: point 1 to 5 with die 4', () => {
+      const initialBoard = [...DEFAULT_BOARD];
+      initialBoard[0] = -1; // Black piece on point 1 (0-indexed)
+      initialBoard[4] = 1;  // White blot on point 5 (0-indexed)
+      const game = createGameState({
+        board: initialBoard,
+        dice: [4, 3],
+        color: 'black',
+      });
+
+      const result = calculateNewMove(game, 0, 4, 4);
+
+      expect(result.moveLabel).toBe('1/5*');
+      expect(result.state.board[0]).toBe(0);
+      expect(result.state.board[4]).toBe(-1); // Black captured point 5
+      expect(result.state.prison.white).toBe(game.prison.white + 1);
+      expect(result.state.dice).toEqual(expect.arrayContaining([0, 3]));
+      expect(result.state.status).toBe('moved');
+    });
+
+    it('White re-entry from bar to point 3 with die 3', () => {
+      const initialBoard = [...DEFAULT_BOARD];
+      initialBoard[2] = 0; // Ensure point 3 (0-indexed: 2) is open
+      const game = createGameState({
+        board: initialBoard,
+        dice: [3, 5],
+        color: 'white',
+        whitePrison: 1,
+      });
+
+      const result = calculateNewMove(game, 'white', 2, 3);
+
+      expect(result.moveLabel).toBe('bar/3');
+      expect(result.state.prison.white).toBe(0);
+      expect(result.state.board[2]).toBe(1);
+      expect(result.state.dice).toEqual(expect.arrayContaining([0, 5]));
+      expect(result.state.status).toBe('moved');
+    });
+
+    it('Black bearing off from point 22 (idx 21) with die 3', () => {
+      const board = Array(24).fill(0);
+      board[18] = -2; board[19] = -2; board[20] = -2; 
+      board[21] = -1; // Piece to bear off (point 22)
+      board[22] = -2; board[23] = -5; 
+      const game = createGameState({
+        board,
+        dice: [3, 1],
+        color: 'black',
+      });
+      // Ensure all black pieces are in home board for bearing off to be valid
+      // For this test, we assume isValidMove allows it based on this setup
+
+      const result = calculateNewMove(game, 21, 'off', 3); // Die 3 -> target 24-3 = 21
+
+      expect(result.moveLabel).toBe('22/off');
+      expect(result.state.board[21]).toBe(0);
+      expect(result.state.home.black).toBe(game.home.black + 1);
+      expect(result.state.dice).toEqual(expect.arrayContaining([0, 1]));
+      expect(result.state.status).toBe('moved');
+    });
+
+    it('Using one die from a pair: [5, 2], use 5', () => {
+      const initialBoard = [...DEFAULT_BOARD];
+      initialBoard[11] = 1; // White piece on point 12
+      const game = createGameState({
+        board: initialBoard,
+        dice: [5, 2],
+        color: 'white',
+      });
+
+      const result = calculateNewMove(game, 11, 6, 5); // point 12 to 7 with die 5
+
+      expect(result.moveLabel).toBe('12/7');
+      expect(result.state.dice.filter(d => d === 0).length).toBe(1);
+      expect(result.state.dice.includes(5)).toBe(false);
+      expect(result.state.dice.includes(2)).toBe(true);
+    });
+    
+    it('Using one die from doubles: [4, 4], use one 4', () => {
+      const initialBoard = [...DEFAULT_BOARD];
+      initialBoard[11] = 1; // White piece on point 12
+      const game = createGameState({
+        board: initialBoard,
+        dice: [4, 4], // Standard dice representation for doubles
+        color: 'white',
+      });
+
+      const result = calculateNewMove(game, 11, 7, 4); // point 12 to 8 with die 4
+
+      expect(result.moveLabel).toBe('12/8');
+      // Check that one 4 is used (becomes 0) and one 4 remains
+      const diceAfterMove = result.state.dice.slice().sort((a,b) => a-b);
+      expect(diceAfterMove).toEqual([0, 4]);
+    });
+  });
+
+  describe('Invalid Moves', () => {
+    it('Attempting a move that isValidMove would reject (e.g., White to blocked Black point)', () => {
+      const initialBoard = [...DEFAULT_BOARD];
+      initialBoard[11] = 1;  // White piece on point 12
+      initialBoard[8] = -2; // Black's blocked point at 9 (0-indexed: 8)
+      const game = createGameState({
+        board: initialBoard,
+        dice: [3, 1],
+        color: 'white',
+      });
+
+      // Attempt to move from 11 to 8 with die 3 (12 to 9)
+      const result = calculateNewMove(game, 11, 8, 3);
+
+      expect(result.moveLabel).toBeUndefined();
+      // Check relevant fields to ensure state is unchanged
+      expect(result.state.board).toEqual(game.board);
+      expect(result.state.dice).toEqual(game.dice); // Dice should not be consumed
+      expect(result.state.prison).toEqual(game.prison);
+      expect(result.state.home).toEqual(game.home);
+      // Status should not change from 'rolled' if move is invalid
+      expect(result.state.status).toBe('rolled'); 
+    });
+
+    it('Attempting to use a die that is already 0 (should be rejected by isValidMove)', () => {
+      // This scenario assumes isValidMove handles dieValueUsed > 0.
+      // calculateNewMove itself does not explicitly check dieValueUsed > 0, it trusts isValidMove.
+      // If isValidMove allows dieValueUsed = 0, this test might show different behavior.
+      // For this test, we expect isValidMove to make this scenario invalid.
+      const initialBoard = [...DEFAULT_BOARD];
+      initialBoard[11] = 1; 
+      const game = createGameState({
+        board: initialBoard,
+        dice: [0, 5], // A die is already used
+        color: 'white',
+      });
+
+      // Attempt to move with the used die (0)
+      // isValidMove should return false because a 0-value die cannot make a valid move (target point calculation etc.)
+      const result = calculateNewMove(game, 11, 11 - 0, 0); // Hypothetical, isValidMove should prevent
+
+      expect(result.moveLabel).toBeUndefined();
+      expect(result.state.board).toEqual(game.board);
+      expect(result.state.dice).toEqual(game.dice);
+      expect(result.state.status).toBe('rolled');
+    });
+  });
+});


### PR DESCRIPTION
I've implemented traditional backgammon rules for validating your moves based on dice rolls for online matches.

Key changes include:
- A new `isValidMove` function in `src/GameLogic/validation.ts` that checks:
    - Standard piece movement (correct distance, direction, ownership).
    - Valid landing spots (empty, own pieces, opponent blots, blocked points).
    - Rules for re-entering pieces from the bar.
    - Rules for bearing off pieces, including when all pieces are in the home board and using higher die rolls.
- A new `calculateNewMove` function in `src/Utils.ts` that:
    - Uses `isValidMove` to authorize a move.
    - Updates the game board, prison, and home counts based on the valid move.
    - Consumes the used die value from your dice.
    - Generates a standard backgammon move notation label.
- Integration of `calculateNewMove` into the main move handling logic in `src/index.tsx`:
    - The `move` function now iterates through available dice to find a valid die for your intended move (`from` and `to` points).
    - The `onDrop` handler for bearing off was updated to use the correct `'off'` parameter.
- I've added comprehensive unit tests for `isValidMove` and `calculateNewMove` to ensure correctness of the new logic, covering a wide range of game scenarios.

This change enhances the game by enforcing core backgammon rules, preventing you from making invalid moves.