### PR TITLE
fix: Prevent Google Translate from messing up icons

### DIFF
--- a/src/Dialogues/Friends.tsx
+++ b/src/Dialogues/Friends.tsx
@@ -110,14 +110,14 @@ export default function Friends({ authUser, toggle, load, reset }) {
                 aria-haspopup="menu"
                 aria-expanded={isExpanded}
                 onPointerUp={() => setIsExpanded(!isExpanded)}
-                className="material-icons"
+                className="material-icons notranslate"
             >
                 settings
             </button>
             <menu>
                 <li>
                     <a onPointerUp={invite}>
-                        <span className="material-icons">person_add_alt_1</span>
+                        <span className="material-icons notranslate">person_add_alt_1</span>
                         Invite Friend
                     </a>
                 </li>
@@ -128,25 +128,31 @@ export default function Friends({ authUser, toggle, load, reset }) {
                     : null}
                 <li>
                     <a onPointerUp={() => toggle('profile')}>
-                        <span className="material-icons">manage_accounts</span>
+                        <span className="material-icons notranslate">manage_accounts</span>
                         Edit Profile
                     </a>
                 </li>
                 <li>
                     <a onPointerUp={reset}>
-                        <span className="material-icons">restart_alt</span>
+                        <span className="material-icons notranslate">restart_alt</span>
                         Reset Match
                     </a>
                 </li>
                 <li>
                     <a href="https://github.com/ProLoser/PeaceInTheMiddleEast/issues/new" target="_blank">
-                        <span className="material-icons">bug_report</span>
+                        <span className="material-icons notranslate">bug_report</span>
                         Report Bug
                     </a>
                 </li>
                 <li>
+                    <a href="https://github.com/ProLoser/PeaceInTheMiddleEast/" target="_blank" rel="noopener noreferrer">
+                        <span className="material-icons notranslate">info</span>
+                        About
+                    </a>
+                </li>
+                <li>
                     <a onPointerUp={() => firebase.auth().signOut()}>
-                        <span className="material-icons">logout</span>
+                        <span className="material-icons notranslate">logout</span>
                         Logout
                     </a>
                 </li>

--- a/src/Dialogues/Login.tsx
+++ b/src/Dialogues/Login.tsx
@@ -84,7 +84,7 @@ export default function Login({ reset, friend, load }: LoginProps) {
                     aria-haspopup="menu"
                     aria-expanded={isExpanded}
                     onPointerUp={() => setIsExpanded(!isExpanded)}
-                    className="material-icons"
+                    className="material-icons notranslate"
                 >
                     settings
                 </button>
@@ -96,13 +96,13 @@ export default function Login({ reset, friend, load }: LoginProps) {
                         : null}
                     <li>
                         <a onPointerUp={reset}>
-                            <span className="material-icons">restart_alt</span>
+                            <span className="material-icons notranslate">restart_alt</span>
                             Reset Match
                         </a>
                     </li>
                     <li>
                         <a href="https://github.com/ProLoser/PeaceInTheMiddleEast/issues/new" target="_blank">
-                            <span className="material-icons">bug_report</span>
+                            <span className="material-icons notranslate">bug_report</span>
                             Report Bug
                         </a>
                     </li>

--- a/src/ToggleFullscreen.tsx
+++ b/src/ToggleFullscreen.tsx
@@ -16,7 +16,7 @@ export default function ToggleFullscreen() {
     }, [])
 
     return <a onPointerUp={toggleFullscreen}>
-        <span className="material-icons">{fullscreen ? 'fullscreen_exit' : 'fullscreen'}</span>
+        <span className="material-icons notranslate">{fullscreen ? 'fullscreen_exit' : 'fullscreen'}</span>
         {fullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
     </a>
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -285,7 +285,7 @@ export function App() {
         <div id="toolbar" onPointerUp={toggle}>
           {friendData
             ? <Avatar user={friendData} />
-            : <a className={`material-icons ${state && 'active' || ''}`}>account_circle</a>}
+            : <a className={`material-icons notranslate ${state && 'active' || ''}`}>account_circle</a>}
           <h2>{friendData?.name ?? 'Local'}</h2>
         </div>
 


### PR DESCRIPTION
Adds the `notranslate` class to all material icons to prevent Google Translate from attempting to translate them, which can mess up their display.