### PR TITLE
Refine dialog outside click detection and remove redundant props

### DIFF
--- a/src/Dialogues/DialogContext.tsx
+++ b/src/Dialogues/DialogContext.tsx
@@ -1,0 +1,17 @@
+import React, { createContext } from 'react';
+import type { ModalState } from '../Types';
+
+// Define ModalState based on its usage in src/index.tsx
+// It can be 'friends', 'profile', 'chat', or false, or other string values.
+// export type ModalState = 'friends' | 'profile' | 'chat' | string | boolean;
+
+export interface DialogContextType {
+  dialogState: ModalState;
+  toggleDialog: (newState: ModalState) => void;
+  lastDialogState: ModalState;
+}
+
+// Provide sensible defaults or undefined if consumers should always expect a provider
+const DialogContext = createContext<DialogContextType | undefined>(undefined);
+
+export default DialogContext;

--- a/src/Dialogues/Friends.tsx
+++ b/src/Dialogues/Friends.tsx
@@ -1,7 +1,8 @@
 // Import FirebaseAuth and firebase.
-import { useState, useCallback, useRef, ReactNode, useEffect } from 'react';
+import { useState, useCallback, useRef, ReactNode, useEffect, useContext } from 'react'; // Added useContext
 import type { ChangeEventHandler } from 'react';
 import { formatDistance } from 'date-fns';
+import DialogContext, { DialogContextType } from './DialogContext'; // Added DialogContext
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
 import 'firebase/compat/database';
@@ -11,7 +12,14 @@ import './Friends.css'
 import ToggleFullscreen from '../ToggleFullscreen';
 type Users = { [key: string]: UserData }
 
-export default function Friends({ authUser, toggle, load, reset }) {
+export default function Friends({ authUser, load, reset }) { // Removed toggle from props
+    const context = useContext(DialogContext);
+    if (!context) {
+        console.error('DialogContext not found in Friends component');
+        return null;
+    }
+    const { toggleDialog } = context; // Destructure toggleDialog from context
+
     const searchRef = useRef<HTMLInputElement>(null);
     const [users, setUsers] = useState<Users>({});
     const [isExpanded, setIsExpanded] = useState(false);
@@ -63,7 +71,7 @@ export default function Friends({ authUser, toggle, load, reset }) {
     const NOW = new Date()
 
     const row = (user: UserData, match?: Match) => 
-        <li key={user.uid} onPointerUp={() => { load(user.uid, authUser.key); toggle() }}>
+        <li key={user.uid} onPointerUp={() => { load(user.uid, authUser.key); toggleDialog(false); }}> {/* Use toggleDialog(false) */}
             <Avatar user={user} />
             <div>
                 <h3>{user.name}</h3>
@@ -127,7 +135,7 @@ export default function Friends({ authUser, toggle, load, reset }) {
                     </li>
                     : null}
                 <li>
-                    <a onPointerUp={() => toggle('profile')}>
+                    <a onPointerUp={() => toggleDialog('profile')}> {/* Use toggleDialog('profile') */}
                         <span className="material-icons notranslate">manage_accounts</span>
                         Edit Profile
                     </a>

--- a/src/Dialogues/Profile.tsx
+++ b/src/Dialogues/Profile.tsx
@@ -1,7 +1,8 @@
 // Import FirebaseAuth and firebase.
-import { useState, useCallback, ChangeEvent, useEffect } from 'react';
+import React, { useState, useCallback, ChangeEvent, useEffect, useContext } from 'react'; // Added React and useContext
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/auth';
+import DialogContext, { DialogContextType } from './DialogContext'; // Added DialogContext
 import 'firebase/compat/database';
 import Avatar from '../Avatar';
 import type { UserData } from '../Types';
@@ -110,7 +111,14 @@ export const LANGUAGES = ["af", "af-NA", "af-ZA", "agq", "agq-CM", "ak", "ak-GH"
     "zh-Hant-TW", "zu", "zu-ZA"];
 
 
-export default function Profile({ authUser, toggle }) {
+export default function Profile({ authUser }) { // Removed toggle from props
+    const context = useContext(DialogContext);
+    if (!context) {
+        console.error('DialogContext not found in Profile component');
+        return null;
+    }
+    const { toggleDialog } = context; // Destructure toggleDialog from context
+
     const [editing, setEditing] = useState<UserData>(authUser?.val() || { uid: '', name: '', language: '', photoURL: '' });
     const [currentNotificationPermission, setCurrentNotificationPermission] = useState(Notification.permission);
 
@@ -120,8 +128,8 @@ export default function Profile({ authUser, toggle }) {
         const userRef = firebase.database().ref(`users/${authUser!.key}`);
         userRef.set(editing);
         console.log('Saved', editing);
-        toggle('friends')
-    }, [editing, authUser]);
+        toggleDialog('friends'); // Use toggleDialog
+    }, [editing, authUser, toggleDialog]); // Added toggleDialog to dependencies
 
     const generateOnChange = (key: string) => (event: ChangeEvent<HTMLInputElement>) => {
         setEditing(editing => ({ ...editing, [key]: event.target.value }));
@@ -140,7 +148,7 @@ export default function Profile({ authUser, toggle }) {
         <form onSubmit={save}>
             <header>
                 <h1>
-                    <a onPointerUp={() => toggle('friends')}>
+                    <a onPointerUp={() => toggleDialog('friends')}> {/* Use toggleDialog */}
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-x"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M18 6l-12 12" /><path d="M6 6l12 12" /></svg>
                     </a>
                     Edit Profile

--- a/src/Dialogues/index.tsx
+++ b/src/Dialogues/index.tsx
@@ -1,0 +1,96 @@
+import React, { useContext, useRef, useEffect } from 'react';
+import DialogContext, { DialogContextType } from './DialogContext';
+import Friends from './Friends';
+import Chat from './Chat';
+import Profile from './Profile';
+import Login from './Login';
+import type { UserData, SnapshotOrNullType } from '../Types'; // Assuming these types are needed from App.tsx
+
+// Props that DialogContainer will receive from App.tsx
+// These are the props that were originally passed to the individual dialog components from App.tsx
+interface DialogContainerProps {
+  user: SnapshotOrNullType; // From App's state
+  friendData: UserData | null | undefined; // From App's state (derived from `friend` snapshot)
+  load: (friendId?: string, authUser?: string) => void; // From App's methods
+  reset: () => void; // From App's methods
+  chats: SnapshotOrNullType; // From App's state
+  // Add any other props that individual dialogs might need from App.tsx
+}
+
+const DialogContainer: React.FC<DialogContainerProps> = ({
+  user,
+  friendData,
+  load,
+  reset,
+  chats,
+}) => {
+  const context = useContext(DialogContext);
+
+  if (!context) {
+    // This should not happen if the provider is set up correctly in App.tsx
+    console.error('DialogContext not found. Make sure DialogProvider is wrapping this component.');
+    return null;
+  }
+
+  const { dialogState, toggleDialog } = context;
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // Determine if the dialog should be open
+  // This combines the logic from the original <dialog open={(friendData&&!user)||!!state}>
+  const isOpen = (friendData && !user) || !!dialogState;
+
+  // Effect for managing "click outside to close"
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      // If the dialog is shown and the click is outside its content
+      if (dialogRef.current && !dialogRef.current.contains(event.target as Node)) {
+        toggleDialog(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, toggleDialog]); // Dependencies for the click outside effect
+
+  // Effect for calling showModal and close on the dialog element
+  useEffect(() => {
+    if (dialogRef.current) {
+      if (isOpen) {
+        if (!dialogRef.current.open) {
+          dialogRef.current.showModal();
+        }
+      } else {
+        if (dialogRef.current.open) {
+          dialogRef.current.close();
+        }
+      }
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null; // Don't render the dialog if it shouldn't be open
+  }
+
+  return (
+    <dialog ref={dialogRef} onCancel={() => toggleDialog(false)}>
+      {user ? (
+        dialogState === 'friends' ? (
+          <Friends authUser={user} load={load} reset={reset} />
+        ) : dialogState === 'profile' ? (
+          <Profile authUser={user} />
+        ) : dialogState === 'chat' ? (
+          <Chat chats={chats} user={user} />
+        ) : null
+      ) : (
+        <Login reset={reset} friend={friendData} load={load} />
+      )}
+    </dialog>
+  );
+};
+
+export default DialogContainer;


### PR DESCRIPTION
This commit improves the "click outside to close" functionality for dialogs and cleans up prop passing.

1.  **Improved "Click Outside to Close" in `DialogContainer` (`src/Dialogues/index.tsx`):**
    *   The event listener for detecting clicks outside the dialog is now attached to the `document` (listening for `mousedown`).
    *   The handler correctly checks if the click target is outside the dialog's content area using `!dialogRef.current.contains(event.target as Node)`.
    *   The listener is only active when a dialog is open (`isOpen` is true) and is properly cleaned up to prevent memory leaks.
    *   This addresses feedback to ensure clicks truly anywhere outside the dialog (not just its backdrop) trigger a close. The `onCancel` event on the `<dialog>` element remains for handling ESC key presses and standard backdrop clicks.

2.  **Cleanup in `DialogContainer` (`src/Dialogues/index.tsx`):**
    *   Removed the redundant `toggleDialog` prop that was being passed to the `Friends` and `Profile` components. These components now correctly source `toggleDialog` directly from the `DialogContext`.

These changes make the dialog closing behavior more robust and align better with your expectations for "click anywhere outside" while also tidying up component interactions.