### PR TITLE
Fix: Handle error when user cancels sharing

### DIFF
--- a/src/Dialogues/Friends.tsx
+++ b/src/Dialogues/Friends.tsx
@@ -119,7 +119,10 @@ export default function Friends({ user, load, reset }: FriendsProps) {
             navigator.share?.({
                 url: shareUrl,
                 title: 'Dean invited you to play Backgammon'
-            })
+            }).catch((error) => {
+                // Handle sharing cancellation or other errors
+                console.error('Error sharing:', error);
+            });
         }
     }
 


### PR DESCRIPTION
Adds a try-catch block to the `invite` function in `src/Dialogues/Friends.tsx` to gracefully handle errors that occur when using the Web Share API (`navigator.share`), such as when a user cancels the share operation. The error is logged to the console.