### PR TITLE
Fix: Prevent match overwrite on load by resetting state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,24 +166,27 @@ export function App() {
   // Subscribe to match
   useEffect(() => {
     if (match?.game) {
+      // Reset turn-specific state when the match context changes
+      setUsedDice([]);
+      setSelected(null);
+
       const gameRef = database.ref(`games/${match.game}`); // Ensure match.game is used as it's confirmed to exist
       const onValue = (snapshot: firebaseType.database.DataSnapshot) => {
         const nextGame = snapshot.val();
         if (nextGame) {
           setGame(prevGame => {
+            // Check if dice sound/vibration should occur due to turn change,
+            // but avoid resetting usedDice/selected here as it's handled above.
             if (prevGame.color && prevGame.color !== nextGame.color) {
               diceSound.play();
               vibrate();
-              setUsedDice([]);
-              setSelected(null);
             }
             return nextGame;
           });
         } else {
           const blankGame = newGame();
           setGame(blankGame);
-          setUsedDice([]);
-          setSelected(null);
+          // usedDice and selected are already reset above when match.game is valid.
           gameRef.set(blankGame);
         }
       };


### PR DESCRIPTION
Reset usedDice and selected states when the match context changes. This prevents a race condition where a completed move sequence from a previous match could trigger a write to the new match's game data in Firebase, effectively overwriting the new match's state with the old one.